### PR TITLE
Minor cleanup

### DIFF
--- a/src/openMVG/multiview/LiGT/LiGT_algorithm.cpp
+++ b/src/openMVG/multiview/LiGT/LiGT_algorithm.cpp
@@ -525,7 +525,7 @@ void LiGTProblem::SolveLiGT(const Eigen::MatrixXd& LTL,
     if (eigs.info() != CompInfo::Successful)
         OPENMVG_LOG_ERROR << " SymEigsShiftSolver failure - expect to have invalid output";
 
-    Eigen::VectorXd evalues = eigs.eigenvalues();
+    const Eigen::VectorXd evalues = eigs.eigenvalues();
     OPENMVG_LOG_INFO << "Eigenvalues found: " << evalues.transpose();
 
     evectors.bottomRows( 3 * num_view_ - 3) = eigs.eigenvectors();
@@ -560,9 +560,9 @@ void LiGTProblem::Solution() {
 
     // algorithm time cost
     double duration = timer.elapsedMs();
-    OPENMVG_LOG_INFO << ">> time for the LiGT algorithm:"
+    OPENMVG_LOG_INFO << ">> time for the LiGT algorithm: "
                      << duration
-                     << "Ms"
+                     << " ms"
                      << "\n===============================================================";
 
     time_use_ = duration;

--- a/src/openMVG/multiview/LiGT/LiGT_algorithm.hpp
+++ b/src/openMVG/multiview/LiGT/LiGT_algorithm.hpp
@@ -96,7 +96,6 @@ public:
                          ObsId& id_rbase);
 
     // [Step.3 in Pose-only algorithm]: calculate local L matrix, update LTL and A_lr matrix
-    // ALR and LTL are local update (to ease parallelism) and must be performed after calling this function
     void BuildLTL(Eigen::MatrixXd& LTL,
                   MatrixXd& A_lr);
 

--- a/src/openMVG/multiview/LiGT/LiGT_algorithm_converter.cpp
+++ b/src/openMVG/multiview/LiGT/LiGT_algorithm_converter.cpp
@@ -96,6 +96,7 @@ void LiGTBuilder::BuildLandmarks(const FeatsPerView& feats_per_view,
              itTracks != map_tracks.end();
              ++itTracks, ++idx)
         {
+          {
             const submapTrack& track = itTracks->second;
             landmarks[idx] = Landmark();
             Observations& obs = landmarks.at(idx).obs;
@@ -105,20 +106,16 @@ void LiGTBuilder::BuildLandmarks(const FeatsPerView& feats_per_view,
                 const size_t featIndex = it->second;
                 auto& pt = feats_per_view.at(imaIndex)[featIndex];
 
-                const Vec2 x = pt.coords().cast<double>();
-
                 const View* view = sfm_data.views.at(imaIndex).get();
                 const IntrinsicBase* cam = sfm_data.GetIntrinsics().at(view->id_intrinsic).get();
 
-                const Matrix3d& Kinv = dynamic_cast<const cameras::Pinhole_Intrinsic*>(cam)->Kinv();
-
                 // Note: LiGT needs to use the normalized feature coordinate
-                Vec2 normalized_coord;
-                normalized_coord(0) = Kinv(0,0) * x(0) + Kinv(0,1) * x(1) + Kinv(0,2) * 1;
-                normalized_coord(1) = Kinv(1,0) * x(0) + Kinv(1,1) * x(1) + Kinv(1,2) * 1;
+                const Vec2 x = cam->get_ud_pixel(pt.coords().cast<double>());
+                Vec2 normalized_coord = (*cam)(x).col(0).hnormalized();
 
                 obs[imaIndex] = Observation(normalized_coord, featIndex);
             }
+          }
         }
     }
 }

--- a/src/openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.cpp
+++ b/src/openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.cpp
@@ -64,13 +64,13 @@ bool GlobalSfM_Translation_AveragingSolver::Run
                 map_globalR,
                 tripletWise_matches);
 
-#ifdef USE_PATENTED_LIGT
-    // ====================  Add LiGT's module ===================
-    // [Note]: Since the function Translation_averaging() is not provided features information,
-    // we add our LiGT's module in this place.
-    bool b_translation;
+    bool b_translation = false;
 
     if (eTranslationAveragingMethod == TRANSLATION_LIGT){
+#ifdef USE_PATENTED_LIGT
+        // ====================  Add LiGT's module ===================
+        // [Note]: Since the function Translation_averaging() is not provided features information,
+        // we add our LiGT's module in this place.
 
         LiGT::LiGTBuilder problem(features_provider->feats_per_view,
                                   tripletWise_matches,
@@ -79,16 +79,17 @@ bool GlobalSfM_Translation_AveragingSolver::Run
 
         problem.Solution();
 
-        LiGT::Poses poses = problem.GetPoses();
+        const LiGT::Poses poses = problem.GetPoses();
 
         // A valid solution was found:
         // - Update the view poses according the found camera translations
         for ( auto& pose : poses)
         {
-            sfm_data.poses[pose.first] = {pose.second.rotation(),pose.second.center()};
+          sfm_data.poses[pose.first] = {pose.second.rotation(),pose.second.center()};
         }
 
         b_translation = true;
+#endif
     }
     else{
         b_translation = Translation_averaging(
@@ -96,12 +97,6 @@ bool GlobalSfM_Translation_AveragingSolver::Run
                     sfm_data,
                     map_globalR);
     }
-#else
-    bool b_translation = Translation_averaging(
-                eTranslationAveragingMethod,
-                sfm_data,
-                map_globalR);
-#endif
 
     // =======================================================
 

--- a/src/openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.hpp
+++ b/src/openMVG/sfm/pipelines/global/GlobalSfM_translation_averaging.hpp
@@ -24,7 +24,6 @@ namespace openMVG { namespace sfm { struct SfM_Data; } }
 namespace openMVG{
 namespace sfm{
 
-#ifdef USE_PATENTED_LIGT
 enum ETranslationAveragingMethod
 {
   TRANSLATION_AVERAGING_L1 = 1,
@@ -32,14 +31,6 @@ enum ETranslationAveragingMethod
   TRANSLATION_AVERAGING_SOFTL1 = 3,
   TRANSLATION_LIGT = 4
 };
-#else
-enum ETranslationAveragingMethod
-{
-  TRANSLATION_AVERAGING_L1 = 1,
-  TRANSLATION_AVERAGING_L2_DISTANCE_CHORDAL = 2,
-  TRANSLATION_AVERAGING_SOFTL1 = 3,
-};
-#endif
 
 struct SfM_Data;
 struct Matches_Provider;

--- a/src/openMVG/sfm/pipelines/global/global_SfM_test.cpp
+++ b/src/openMVG/sfm/pipelines/global/global_SfM_test.cpp
@@ -242,6 +242,60 @@ TEST(GLOBAL_SFM, RotationAveragingL2_TranslationAveragingSoftL1) {
   EXPECT_TRUE( IsTracksOneCC(sfmEngine.Get_SfM_Data()));
 }
 
+#ifdef USE_PATENTED_LIGT
+TEST(GLOBAL_SFM, RotationAveragingL2_Translation_LIGT) {
+
+  const int nviews = 6;
+  const int npoints = 64;
+  const nViewDatasetConfigurator config;
+  const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
+
+  // Translate the input dataset to a SfM_Data scene
+  const SfM_Data sfm_data = getInputScene(d, config, PINHOLE_CAMERA);
+
+  // Remove poses and structure
+  SfM_Data sfm_data_2 = sfm_data;
+  sfm_data_2.poses.clear();
+  sfm_data_2.structure.clear();
+
+  GlobalSfMReconstructionEngine_RelativeMotions sfmEngine(
+    sfm_data_2,
+    "./",
+    stlplus::create_filespec("./", "Reconstruction_Report.html"));
+
+  // Configure the features_provider & the matches_provider from the synthetic dataset
+  std::shared_ptr<Features_Provider> feats_provider =
+    std::make_shared<Synthetic_Features_Provider>();
+  // Add a tiny noise in 2D observations to make data more realistic
+  std::normal_distribution<double> distribution(0.0,0.5);
+  dynamic_cast<Synthetic_Features_Provider*>(feats_provider.get())->load(d,distribution);
+
+  std::shared_ptr<Matches_Provider> matches_provider =
+    std::make_shared<Synthetic_Matches_Provider>();
+  dynamic_cast<Synthetic_Matches_Provider*>(matches_provider.get())->load(d);
+
+  // Configure data provider (Features and Matches)
+  sfmEngine.SetFeaturesProvider(feats_provider.get());
+  sfmEngine.SetMatchesProvider(matches_provider.get());
+
+  // Configure reconstruction parameters (intrinsic parameters are held constant)
+  sfmEngine.Set_Intrinsics_Refinement_Type(cameras::Intrinsic_Parameter_Type::NONE);
+
+  // Configure motion averaging methods
+  sfmEngine.SetRotationAveragingMethod(ROTATION_AVERAGING_L2);
+  sfmEngine.SetTranslationAveragingMethod(TRANSLATION_LIGT);
+
+  EXPECT_TRUE (sfmEngine.Process());
+
+  const double dResidual = RMSE(sfmEngine.Get_SfM_Data());
+  std::cout << "RMSE residual: " << dResidual << std::endl;
+  EXPECT_TRUE( dResidual < 0.5);
+  EXPECT_EQ( nviews, sfmEngine.Get_SfM_Data().GetPoses().size());
+  EXPECT_EQ( npoints, sfmEngine.Get_SfM_Data().GetLandmarks().size());
+  EXPECT_TRUE( IsTracksOneCC(sfmEngine.Get_SfM_Data()));
+}
+#endif USE_PATENTED_LIGT
+
 /* ************************************************************************* */
 int main() { TestResult tr; return TestRegistry::runAllTests(tr);}
 /* ************************************************************************* */

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -144,14 +144,6 @@ target_link_libraries(openMVG_main_MatchesToTracks
     ${STLPLUS_LIBRARY}
 )
 
-FIND_PACKAGE( OpenMP REQUIRED)
-if(OPENMP_FOUND)
-message("OPENMP FOUND")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-endif()
-
 add_executable(openMVG_main_LiGT main_LiGT_algorithm.cpp)
 target_link_libraries(openMVG_main_LiGT
   PRIVATE

--- a/src/software/SfM/main_SfM.cpp
+++ b/src/software/SfM/main_SfM.cpp
@@ -283,7 +283,8 @@ int main(int argc, char **argv)
                                         << "\t[-t|--translationAveraging]:\n"
                                         << "\t\t 1 -> L1 minimization\n"
                                         << "\t\t 2 -> L2 minimization of sum of squared Chordal distances\n"
-                                        << "\t\t 3 -> SoftL1 minimization (default)\n";
+                                        << "\t\t 3 -> SoftL1 minimization (default)\n"
+                                        << "\t\t 4 -> LiGT: Linear Global Translation constraints from rotation and matches\n";
 
         OPENMVG_LOG_ERROR << s;
         return EXIT_FAILURE;
@@ -338,19 +339,17 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-#ifdef USE_PATENTED_LIGT
+#ifndef USE_PATENTED_LIGT
+    if (translation_averaging_method == TRANSLATION_LIGT) {
+        OPENMVG_LOG_ERROR << "OpenMVG was not compiled with USE_PATENTED_LIGT cmake option";
+        return EXIT_FAILURE;
+    }
+#endif
     if (translation_averaging_method < TRANSLATION_AVERAGING_L1 ||
             translation_averaging_method > TRANSLATION_LIGT )  {
         OPENMVG_LOG_ERROR << "Translation averaging method is invalid";
         return EXIT_FAILURE;
     }
-#else
-    if (translation_averaging_method < TRANSLATION_AVERAGING_L1 ||
-            translation_averaging_method > TRANSLATION_AVERAGING_SOFTL1 )  {
-        OPENMVG_LOG_ERROR << "Translation averaging method is invalid";
-        return EXIT_FAILURE;
-    }
-#endif
 
     if (directory_output.empty())  {
         OPENMVG_LOG_ERROR << "It is an invalid output directory";


### PR DESCRIPTION
- Use bearing vectors computation to initialize track with normalized features
- Minor cleanup for TRANSLATION_LIGT (always defined, but code working only if USE_PATENTED_LIGT is active)
- Added LIGT translation as a GlobalSfM unit test